### PR TITLE
Remove unused call to plugins import

### DIFF
--- a/modules/neovim/config/lazy.lua
+++ b/modules/neovim/config/lazy.lua
@@ -15,7 +15,7 @@ require("lazy").setup({
     -- { import = "lazyvim.plugins.extras.lang.json" },
     -- { import = "lazyvim.plugins.extras.ui.mini-animate" },
     -- import/override with your plugins
-    { import = "plugins" },
+    -- { import = "plugins" },
   },
   defaults = {
     -- By default, only LazyVim plugins will be lazy-loaded. Your custom plugins will load during startup.


### PR DESCRIPTION
- This is not currently being used and since the folder does not exist, it was throwing an error during startup.  Will add something in to handle the folder later, if I end up needing it for anything.