### PR TITLE
Improve Git Scripts

### DIFF
--- a/git-scripts/cleanpush
+++ b/git-scripts/cleanpush
@@ -3,40 +3,39 @@
 currentBranch=$(git branch --show-current)
 
 # Rebase your current base with main
-git checkout main || exit 1
+git checkout $1 || exit 1
 git pull --rebase
 git checkout ${currentBranch}
-git rebase main
+git rebase $1
 
 # This checks to see if your branch is already up to date with main. This should not cause it to fail, so
 # check the response and continue only if it says up to date, else fail because an error happened.
-responseMessage=$( git rebase main 2>&1)
+responseMessage=$(git rebase $1 2>&1)
 if [[ $responseMessage=="Current branch ${currentBranch} is up to date." ]]; then
-    echo "No changes to merge with for main, continuing."
+	echo "No changes to merge with for $1, continuing."
 else
-    if [[ $?!=0 ]]; then
-        echo "Error with rebase, quitting."
-        exit 1
-    fi
+	if [[ $?!=0 ]]; then
+		echo "Error with rebase, quitting."
+		exit 1
+	fi
 fi
 
-originMain=$(git rev-parse --short origin/main)
+origin=$(git rev-parse --short origin/$1)
 
 # Rebase and squash your commits
-read -p "Run 'git rebase -i ${originMain}'? (Y/Q): " confirm
+read -p "Run 'git rebase -i ${origin}'? (Y/Q): " confirm
 if [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; then
-    git rebase -i ${originMain}
+	git rebase -i ${origin}
 else
-    echo "Quitting."
-    exit 1
+	echo "Quitting."
+	exit 1
 fi
-
 
 # Push branch to github
 read -p "Run 'git push origin ${currentBranch}'? (Y/Q): " confirm
 if [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; then
-    git push origin ${currentBranch} --force
+	git push origin ${currentBranch} --force
 else
-    echo "Quitting."
-    exit 1
+	echo "Quitting."
+	exit 1
 fi

--- a/git-scripts/rebase
+++ b/git-scripts/rebase
@@ -3,19 +3,19 @@
 currentBranch=$(git branch --show-current)
 
 # Rebase your current base with main
-git checkout main || exit 1
+git checkout $1 || exit 1
 git pull --rebase
 git checkout ${currentBranch}
-git rebase main
+git rebase $1
 
 # This checks to see if your branch is already up to date with main. This should not cause it to fail, so
 # check the response and continue only if it says up to date, else fail because an error happened.
-responseMessage=$( git rebase main 2>&1)
+responseMessage=$(git rebase $1 2>&1)
 if [[ $responseMessage=="Current branch ${currentBranch} is up to date." ]]; then
-    echo "No changes to merge with for main, continuing."
+	echo "No changes to merge with for main, continuing."
 else
-    if [[ $?!=0 ]]; then
-        echo "Error with rebase, quitting."
-        exit 1
-    fi
+	if [[ $?!=0 ]]; then
+		echo "Error with rebase, quitting."
+		exit 1
+	fi
 fi

--- a/modules/fish/default.nix
+++ b/modules/fish/default.nix
@@ -10,8 +10,8 @@
       # git-related
       alias g='git'
       alias git-rm-branches='git for-each-ref --format "%(refname:short)" refs/heads | grep -v "master\|main\|develop\|development" | xargs git branch -D'
-      alias cleanpush='/bin/sh ~/nix-configs/git-scripts/cleanpush'
-      alias rebase='/bin/sh ~/nix-configs/git-scripts/rebase'
+      alias cleanpush='/bin/bash ~/nix-configs/git-scripts/cleanpush'
+      alias rebase='/bin/bash ~/nix-configs/git-scripts/rebase'
 
       # home-manager
       alias hmd='cd ~/nix-configs'


### PR DESCRIPTION
- Explicitly pointed aliases to use bash instead of just sh, since some systems link sh to something else.
- Added the ability to pass a branch name in to the git scripts, since not all repos use the same names for their main branches.